### PR TITLE
Add specifying parent folder for binary files

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -34,6 +34,13 @@ export class MetaDataGenerator {
 		if (!(file instanceof TFile)) {
 			return false;
 		}
+		if (
+			!file.path.startsWith(
+				normalizePath(this.plugin.settings.binaryFilePath)
+			)
+		) {
+			return false;
+		}
 
 		const matchedExtension =
 			this.plugin.fileExtensionManager.getExtensionMatchedBest(file.name);

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -118,6 +118,20 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 					});
 			});
 
+		new Setting(containerEl)
+			.setName('Binary file parent folder')
+			.setDesc('Only this folder will be watched for new files')
+			.addSearch((component) => {
+				new FolderSuggest(this.app, component.inputEl);
+				component
+					.setPlaceholder('Example: folder1/folder2')
+					.setValue(this.plugin.settings.binaryFilePath)
+					.onChange((newFolder) => {
+						this.plugin.settings.binaryFilePath = newFolder;
+						this.plugin.saveSettings();
+					});
+			});
+
 		let extensionToBeAdded: string;
 		new Setting(containerEl)
 			.setName('Extension to be watched')

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ interface BinaryFileManagerSettings {
 	autoDetection: boolean;
 	extensions: string[];
 	folder: string;
+	binaryFilePath: string;
 	filenameFormat: string;
 	templatePath: string;
 	useTemplater: boolean;
@@ -36,6 +37,7 @@ const DEFAULT_SETTINGS: BinaryFileManagerSettings = {
 		'pdf',
 	],
 	folder: '/',
+	binaryFilePath: '/',
 	filenameFormat: 'INFO_{{NAME}}_{{EXTENSION:UP}}',
 	templatePath: '',
 	useTemplater: false,


### PR DESCRIPTION
This addresses #6 by adding a new setting for which folder to watch for new binary files.  When new files are detected, they are compared against the setting, and if the string paths match, the metadata file creation is triggered.

I didn't bump any versions or anything, and if there are changes that would help the patch I'm more than happy to make them!
