### PR TITLE
Option to keep metadata files in same folder as original

### DIFF
--- a/src/Generator.ts
+++ b/src/Generator.ts
@@ -49,10 +49,10 @@ export class MetaDataGenerator {
 	}
 
 	async create(file: TFile) {
-		const metaDataFileName = this.uniquefyMetaDataFileName(
-			this.generateMetaDataFileName(file)
-		);
-		const metaDataFilePath = `${this.plugin.settings.folder}/${metaDataFileName}`;
+		const metaDataFileName = this.generateMetaDataFileName(file)
+		const metaDataFileDirectory = this.plugin.settings.folder === "./" ? file.parent.path : this.plugin.settings.folder;
+		const uniqueMetaDataFileName = this.uniquefyMetaDataFileName(metaDataFileName, metaDataFileDirectory);
+		const metaDataFilePath = `${metaDataFileDirectory}/${uniqueMetaDataFileName}`;
 
 		await this.createMetaDataFile(metaDataFilePath, file as TFile);
 	}
@@ -66,9 +66,9 @@ export class MetaDataGenerator {
 		return metaDataFileName;
 	}
 
-	private uniquefyMetaDataFileName(metaDataFileName: string): string {
+	private uniquefyMetaDataFileName(metaDataFileName: string, metaDataFileDirectory: string): string {
 		const metaDataFilePath = normalizePath(
-			`${this.plugin.settings.folder}/${metaDataFileName}`
+			`${metaDataFileDirectory}/${metaDataFileName}`
 		);
 		if (this.app.vault.getAbstractFileByPath(metaDataFilePath)) {
 			return `CONFLICT-${moment().format(

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -48,7 +48,7 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 					.setPlaceholder('Example: folder1/folder2')
 					.setValue(this.plugin.settings.folder)
 					.onChange((newFolder) => {
-						this.plugin.settings.folder = newFolder;
+						this.plugin.settings.folder = newFolder.trim();
 						this.plugin.saveSettings();
 					});
 			});

--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -41,7 +41,11 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 
 		new Setting(containerEl)
 			.setName('New file location')
-			.setDesc('New metadata file will be placed here')
+			.setDesc(createFragment(fragment => {
+				fragment.appendText('New metadata file will be placed here')
+				fragment.createEl("br")
+				fragment.appendText('Set to "./" to place in the same folder as the original file.')
+			}))
 			.addSearch((component) => {
 				new FolderSuggest(this.app, component.inputEl);
 				component


### PR DESCRIPTION
This addresses issue #4.

If the user sets the folder setting to "./", then the metadata files will be placed in the same directory as the original file.