### PR TITLE
Implement Ignored Paths

### DIFF
--- a/src/Setting.ts
+++ b/src/Setting.ts
@@ -40,6 +40,25 @@ export class BinaryFileManagerSettingTab extends PluginSettingTab {
 			});
 
 		new Setting(containerEl)
+			.setName('Ignored directories')
+			.setDesc(
+				'Directory paths to ignore during auto detection. One path per line. Wildcards supported (e.g., archives/*, *inbox)'
+			)
+			.addTextArea((textArea) => {
+				textArea
+					.setPlaceholder('archives/*\n*inbox\ntemp/')
+					.setValue(this.plugin.settings.ignoredPaths.join('\n'))
+					.onChange(async (value: string) => {
+						this.plugin.settings.ignoredPaths = value
+							.split('\n')
+							.map((path) => path.trim())
+							.filter((path) => path.length > 0);
+						await this.plugin.saveSettings();
+					});
+				textArea.inputEl.rows = 4;
+			});
+
+		new Setting(containerEl)
 			.setName('New file location')
 			.setDesc('New metadata file will be placed here')
 			.addSearch((component) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -109,6 +109,11 @@ export default class BinaryFileManagerPlugin extends Plugin {
 						continue;
 					}
 
+					// Check if the file path should be ignored during manual detection
+					if (this.isPathIgnored(file.path)) {
+						return;
+					}
+
 					promises.push(
 						this.metaDataGenerator
 							.create(file as TFile)
@@ -133,6 +138,10 @@ export default class BinaryFileManagerPlugin extends Plugin {
 				const unlinkedFiles =
 					this.metaDataGenerator.findUnlinkedBinaries();
 				unlinkedFiles.forEach((file) => {
+					// Check if the file path should be ignored during unlinked detection
+					if (this.isPathIgnored(file.path)) {
+						return;
+					}
 					promises.push(
 						this.metaDataGenerator
 							.create(file as TFile)


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This pull request implements the ability to set ignore directories during auto detection.

A multiline input is provide for users to add directory paths to ignore during auto detection. One path per line, wildcards supported.

Does this close any currently open issues?
------------------------------------------
- This address #2 : Ignore Folder
- This partially addresses #6 

Any other comments?
-------------------
Versions were not bumped.

Where has this been tested?
---------------------------
**Obsidian Desktop:** 1.10.6
**Obsidian Installer:** 1.9.14