### PR TITLE
Introduce tagpr for automated releases

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,40 @@
+name: tagpr
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    outputs:
+      tagpr-tag: ${{ steps.tagpr.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: tagpr
+        uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release:
+    needs: [tagpr]
+    if: needs.tagpr.outputs.tagpr-tag != ''
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Upload build artifact to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            main.js
+            manifest.json
+            styles.css
+          tag_name: ${{ needs.tagpr.outputs.tagpr-tag }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,5 @@
+[tagpr]
+    releaseBranch = main
+    vPrefix = false
+    versionFile = manifest.json
+    release = false


### PR DESCRIPTION
Same setup as obsidian-core-search-assistant-plugin: tagpr opens a
release PR on pushes to main; merging it tags the release and a release
job builds main.js and attaches the plugin artifacts.
