### PR TITLE
build: harden pnpm settings (minimum-release-age, exact pins, pinned pnpm)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,12 @@
+# Supply-chain hardening for pnpm (see https://pnpm.io/settings).
+# `pnpm add` writes exact versions (no ^ / ~) so nothing drifts without a lockfile change.
+save-exact=true
+# Refuse to install under a Node that does not satisfy package.json "engines".
+engine-strict=true
+# Verify the content-addressable store against its hashes (default, made explicit).
+verify-store-integrity=true
+# Refuse versions published less than 7 days (10080 min) ago: compromised releases
+# are usually yanked or reported within days.
+minimum-release-age=10080
+auto-install-peers=true
+strict-peer-dependencies=false

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "22"
-pnpm = "10.9"
+pnpm = "10.33.2"
 
 # Pin GitHub Actions to commit SHAs so a re-pointed tag can't run code we never reviewed.
 # pinact is scoped to these tasks (not [tools]) so CI's `mise install` doesn't pull it in.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
 	"version": "0.12.0",
 	"description": "This plugin detects new binary files in the vault and create markdown files with metadata.",
 	"main": "main.js",
+	"packageManager": "pnpm@10.33.2",
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"fix:prettier": "prettier --write src",
 		"lint:prettier": "prettier --check src",


### PR DESCRIPTION
Applies the pnpm supply-chain hardening recipe already used in qawatake/obsidian-e2e-sample#9. **The lockfile does not change**; verified locally that `pnpm install --frozen-lockfile` and `pnpm build` pass with pnpm 10.33.2.

| setting | where | why |
|---|---|---|
| `minimum-release-age=10080` | `.npmrc` | refuse versions published < 7 days ago — compromised releases (chalk/debug 2025-09 etc.) are usually yanked within hours/days. This is the one control that guards *dependency updates* against a compromised maintainer. |
| `save-exact=true` | `.npmrc` | `pnpm add` writes exact versions |
| `engine-strict=true` + `engines.node >=22` | `.npmrc` / `package.json` | refuse mismatched Node |
| `verify-store-integrity=true` | `.npmrc` | default, made explicit |
| `packageManager: pnpm@10.33.2` | `package.json` | package manager pinned; `mise.toml` bumped from 10.9 to the same exact version (`minimum-release-age` needs ≥10.16) |

No CI audit gate: Dependabot alerts are enabled on this repo and cover that.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8
