### PR TITLE
ci: add Dependabot version updates with a 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # Dependabot resolves versions itself, so .npmrc's minimum-release-age does
+    # not apply to its PRs. Mirror it: wait 7 days after a release before proposing it.
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch
+      npm-major:
+        update-types:
+          - major


### PR DESCRIPTION
Adds Dependabot **version updates** (weekly PRs for GitHub Actions and npm), copied from qawatake/obsidian-card-view-switcher-plugin, plus a 7-day `cooldown`.

- `github-actions`: keeps the SHA-pinned `uses:` lines current (Dependabot understands the `# vX.Y.Z` comment format pinact writes).
- `npm`: minor/patch grouped into one PR, majors separate.
- `cooldown: 7 days`: Dependabot resolves versions on GitHub's side, so `.npmrc`'s `minimum-release-age` does not apply to its PRs. The cooldown mirrors it so a freshly published (possibly compromised) version is never proposed before it has had a week to be yanked.

Dependabot *alerts* / security updates were already enabled; this only adds the scheduled update PRs.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8
