### PR TITLE
build: move to Node 24 (current Active LTS)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "22"
+node = "24"
 pnpm = "10.33.2"
 
 # Pin GitHub Actions to commit SHAs so a re-pointed tag can't run code we never reviewed.


### PR DESCRIPTION
Node 22 entered Maintenance LTS in 2025-10 (security fixes only) and reaches EOL in 2027-04; Node 24 is the current Active LTS (Maintenance from 2026-10, EOL 2028-04). `mise.toml` is not covered by Dependabot, so this has to be bumped by hand — doing it now rather than discovering it at EOL.

Only `mise.toml` changes (`engines.node >=22` already allows 24). Verified locally that `pnpm install --frozen-lockfile && pnpm build` pass on Node 24; CI covers the rest.

https://claude.ai/code/session_01Q9cAkmBH4gYHqHcv3XVDr8
