### PR TITLE
chore: bump biome.jsonc $schema to 2.5.10

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.10/schema.json",
 	"vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
 	"files": { "ignoreUnknown": false, "includes": ["**/src/**/*.ts"] },
 	// Matches the previous .prettierrc / .editorconfig: tabs, single quotes, es5 trailing commas.


### PR DESCRIPTION
Follow-up to #46. `@biomejs/biome` was bumped to 2.5.10 but `biome.jsonc`'s `$schema` still pointed at 2.5.8 (dependabot does not touch it). No behavior change: `pnpm lint` output is identical.

https://claude.ai/code/session_019TYM3yx67mK6jXB4Gwxcgb