### PR TITLE
Block lifecycle scripts of dependencies explicitly

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,2 @@
-# esbuild ships prebuilt binaries via optionalDependencies; its postinstall is
-# only a sanity check, so keep pnpm 10 blocking it (and every other lifecycle
-# script) instead of allow-listing anything.
-ignoredBuiltDependencies:
-  - esbuild
+# Packages allowed to run lifecycle (postinstall) scripts. Everything else is blocked.
+onlyBuiltDependencies: []


### PR DESCRIPTION
**a. `pnpm-workspace.yaml` に `onlyBuiltDependencies: []` を追加**
pnpm 10 は allowlist に無い依存の postinstall を既定で走らせないが、明示の空 list にすることで方針が repo に見え、install 時の warning も消える (harden-deps 原則 e)。lockfile は変わらない。

**b. 検証**
`pnpm install --frozen-lockfile` と `pnpm build` が通ることを確認した。